### PR TITLE
兼容 addappid 第二个参数为 0 的情况

### DIFF
--- a/backend/cai_backend.py
+++ b/backend/cai_backend.py
@@ -2838,7 +2838,7 @@ class CaiBackend:
             return True
 
     def parse_lua_file_for_depots(self, lua_file_path: str) -> Dict:
-        addappid_pattern = re.compile(r'addappid\((\d+),\s*1,\s*"([^"]+)"\)')
+        addappid_pattern = re.compile(r'addappid\((\d+),\s*[01],\s*"([^"]+)"\)')
         depots = {}
         try:
             with open(lua_file_path, 'r', encoding='utf-8') as file:


### PR DESCRIPTION
OpenSteamTool示例中第二个参数为0，且实现中根本没用到第二个参数。为了增加兼容性，应该允许0或1。